### PR TITLE
Format source with two spaces as-is standard in Hadoop ecosystem

### DIFF
--- a/src/main/java/com/company/KafkaProducerTest.java
+++ b/src/main/java/com/company/KafkaProducerTest.java
@@ -6,23 +6,21 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 
-
-public class KafkaProducerTest {
-
-            public static void main(String[] args) {
-
-            Properties props = new Properties();
-            props.put("bootstrap.servers","localhost:9092");
-            props.put("acks","all");
-            props.put("retries",0);
-            props.put("batch.size",16384);
-            props.put("linger.ms",1);
-            props.put("buffer.memory",33554432);
-            props.put("key.serializer","org.apache.kafka.common.serialization.StringSerializer");
-            props.put("value.serializer","org.apache.kafka.common.serialization.StringSerializer");
-
-            Producer<String, String> producer = new KafkaProducer(props);
-            for( int i = 0; i<100;i++) producer.send(new ProducerRecord<String, String>("my-topic",Integer.toString(i),Integer.toString(i)));
-                producer.close();
-        }
+public class  KafkaProducerTest {
+  public static void main(String[] args) {
+    Properties props = new Properties();
+    props.put("bootstrap.servers", "localhost:9092");
+    props.put("acks", "all");
+    props.put("retries", 0);
+    props.put("batch.size", 16384);
+    props.put("linger.ms", 1);
+    props.put("buffer.memory", 33554432);
+    props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+    props.put("value.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+    Producer<String, String> producer = new KafkaProducer(props);
+    for (int i = 0; i < 100; i++) {
+      producer.send(new ProducerRecord<String, String> ("my-topic", Integer.toString(i), Integer.toString(i)));
+    }
+    producer. close();
+  }
 }


### PR DESCRIPTION
I reformatted the source code with two spaces.
